### PR TITLE
Cumulative Update for Keras 2.2.0 and some fixes and Explanations in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ See docs/ directory for more features.
 # Installation
 
 ```shell
-git clone https://www.github.com/pyrestone/recurrentshop.git
+git clone https://www.github.com/farizrahman4u/recurrentshop.git
 cd recurrentshop
 python setup.py install
 ```

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ print(out.shape)#->(1,10)
 # to get one output per input sequence element, set return_sequences=True
 rnn2 = RecurrentModel(input=x_t, initial_states=[h_tm1], output=h_t, final_states=[h_t],return_sequences=True)
 
-# Time_steps can also be None
+# Time_steps can also be None to allow variable Sequence Length
+# Note that this is not compatible with unroll=True
 x = Input(shape=(None ,5))
 y = rnn2(x)
 model2 = Model(x, y)

--- a/README.md
+++ b/README.md
@@ -147,15 +147,9 @@ See docs/ directory for more features.
 # Installation
 
 ```shell
-git clone https://www.github.com/datalogai/recurrentshop.git
+git clone https://www.github.com/pyrestone/recurrentshop.git
 cd recurrentshop
 python setup.py install
-```
-
-note that Recurrentshop is not compatible with keras 2.2.*, so it is recommended to use keras==2.0.5:
-
-```shell
-pip install -U keras==2.0.5
 ```
 
 # Contribute

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ from keras.layers import *
 from keras.models import *
 from recurrentshop import *
 
-x_t = Input(5,)) # The input to the RNN at time t
-h_tm1 = Input((10,))  # Previous hidden state
+x_t = Input(shape=(5,)) # The input to the RNN at time t
+h_tm1 = Input(shape=(10,))  # Previous hidden state
 
 # Compute new hidden state
 h_t = add([Dense(10)(x_t), Dense(10, use_bias=False)(h_tm1)])
@@ -34,17 +34,34 @@ h_t = add([Dense(10)(x_t), Dense(10, use_bias=False)(h_tm1)])
 h_t = Activation('tanh')(h_t)
 
 # Build the RNN
-rnn = RecurrentModel(input=x_t, initial_states=[h_tm1], output=h_t, output_states=[h_t])
+# RecurrentModel is a standard Keras `Recurrent` layer. 
+# RecurrentModel also accepts arguments such as unroll, return_sequences etc
+rnn = RecurrentModel(input=x_t, initial_states=[h_tm1], output=h_t, final_states=[h_t])
+# return_sequences is False by default
+# so it only returns the last h_t state
 
-# rnn is a standard Keras `Recurrent` instance. RecuurentModel also accepts arguments such as unroll, return_sequences etc
+# Build a Keras Model using our RNN layer
+# input dimensions are (Time_steps, Depth)
+x = Input(shape=(7,5))
+y = rnn(x)
+model = Model(x, y)
 
 # Run the RNN over a random sequence
+# Don't forget the batch shape when calling the model!
+out=model.predict(np.random.random((1, 7, 5)))
+print(out.shape)#->(1,10)
 
-x = Input((7,5))
-y = rnn(x)
 
-model = Model(x, y)
-model.predict(np.random.random((7, 5)))
+# to get one output per input sequence element, set return_sequences=True
+rnn2 = RecurrentModel(input=x_t, initial_states=[h_tm1], output=h_t, final_states=[h_t],return_sequences=True)
+
+# Time_steps can also be None
+x = Input(shape=(None ,5))
+y = rnn2(x)
+model2 = Model(x, y)
+
+out2=model2.predict(np.random.random((1, 7, 5)))
+print(out2.shape)#->(1,7,10)
 
 ```
 
@@ -132,6 +149,12 @@ See docs/ directory for more features.
 git clone https://www.github.com/datalogai/recurrentshop.git
 cd recurrentshop
 python setup.py install
+```
+
+note that Recurrentshop is not compatible with keras 2.2.*, so it is recommended to use keras==2.0.5:
+
+```shell
+pip install -U keras==2.0.5
 ```
 
 # Contribute

--- a/recurrentshop/engine.py
+++ b/recurrentshop/engine.py
@@ -3,7 +3,8 @@ from keras.models import Model
 from keras import initializers
 from .backend import rnn, learning_phase_scope
 from .generic_utils import serialize_function, deserialize_function
-from keras.engine.topology import Node, _collect_previous_mask, _collect_input_shape
+from keras.engine.topology import Node
+from keras.engine.base_layer import _collect_previous_mask, _collect_input_shape
 import inspect
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-keras>=2.0.0
+keras>=2.2.0
 numpy>=1.8.0
-theano>=0.8.0
+tensorflow>=1.9


### PR DESCRIPTION
This Pull request includes fixes for the issues addressed in #102 #101, #96, #94 and #76 
along with the bug in farizrahman4u/seq2seq#177 and farizrahman4u/seq2seq#250 
(both caused by calls to the deprecated  `keras.engine.topology` class.)