### PR TITLE
make installation a one-liner in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,7 @@ See docs/ directory for more features.
 # Installation
 
 ```shell
-git clone https://www.github.com/farizrahman4u/recurrentshop.git
-cd recurrentshop
-python setup.py install
+sudo pip install git+https://www.github.com/farizrahman4u/recurrentshop.git
 ```
 
 # Contribute


### PR DESCRIPTION
instead of cloning the repository and running `python setup.py` install, use the `pip install URL` syntax.