### PR TITLE
recurrentshop: NameError: name 'K' is not defined

### DIFF
--- a/recurrentshop/engine.py
+++ b/recurrentshop/engine.py
@@ -4,6 +4,7 @@ from keras import initializers
 from .backend import rnn, learning_phase_scope
 from .generic_utils import serialize_function, deserialize_function
 from keras.engine.base_layer import Node,_collect_previous_mask, _collect_input_shape
+from keras import backend as K
 import inspect
 
 


### PR DESCRIPTION
There is small bug in recurrentshop, due to which post installation cannot import the library.
A bug `NameError: name 'K' is not defined` is being incurred. fixed this by adding the line 
`from keras import backend as K` to `engine.py` of `recurrentshop`

this PR solved these issues - https://github.com/farizrahman4u/seq2seq/issues/165 and 
https://github.com/farizrahman4u/recurrentshop/issues/119